### PR TITLE
swiper/DemoEffectCards: remove CSS aka-hack

### DIFF
--- a/src/content/docs/packages/astro-swiper/DemoEffectCards.astro
+++ b/src/content/docs/packages/astro-swiper/DemoEffectCards.astro
@@ -4,71 +4,66 @@
 //
 
 import { Swiper, SwiperWrapper, SwiperSlide, } from "astro-swiper";
-import './demo.css'
 import DemoFirstSlide from "./DemoFirstSlide.astro";
+import './demo.css' // .my-slide definition: colors, aspect-ratio, sizes,...
 
 const title='Effect Cards'
 ---
 
 <Swiper
-  uniqueClass="my-swiper-demoeffectcards"
   options={{
     effect: "cards",
     grabCursor: true,
   }}
 >
   <SwiperWrapper>
-    <SwiperSlide> <div class="my-slide"> <DemoFirstSlide title={title}/> </div> </SwiperSlide>
-    <SwiperSlide> <div class="my-slide"> <img src="/astro-dev/astro-swiper.png" alt="" /> </div> </SwiperSlide>
-    <SwiperSlide> <div class="my-slide"> <img src="https://swiperjs.com/demos/images/nature-1.jpg" /> </div> </SwiperSlide>
-    <SwiperSlide> <div class="my-slide"> <img src="https://swiperjs.com/demos/images/nature-2.jpg" /> </div> </SwiperSlide>
-    <SwiperSlide> <div class="my-slide"> <img src="https://swiperjs.com/demos/images/nature-3.jpg" /> </div> </SwiperSlide>
-    <SwiperSlide> <div class="my-slide"> <img src="https://swiperjs.com/demos/images/nature-4.jpg" /> </div> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <DemoFirstSlide title={title}/> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <img src="/astro-dev/astro-swiper.png" alt="" /> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <img src="https://swiperjs.com/demos/images/nature-1.jpg" /> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <img src="https://swiperjs.com/demos/images/nature-2.jpg" /> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <img src="https://swiperjs.com/demos/images/nature-3.jpg" /> </SwiperSlide>
+    <SwiperSlide class="my-slide slide-this-demo"> <img src="https://swiperjs.com/demos/images/nature-4.jpg" /> </SwiperSlide>
   </SwiperWrapper>
 </Swiper>
 
 <style>
-  .my-swiper-demoeffectcards .my-slide {
-    background-color: unset;
-  }
-
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(1n) {
+  .slide-this-demo:nth-child(1n) {
     background-color: rgb(206, 17, 17);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(2n) {
+  .slide-this-demo:nth-child(2n) {
     background-color: rgb(0, 140, 255);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(3n) {
+  .slide-this-demo:nth-child(3n) {
     background-color: rgb(10, 184, 111);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(4n) {
+  .slide-this-demo:nth-child(4n) {
     background-color: rgb(211, 122, 7);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(5n) {
+  .slide-this-demo:nth-child(5n) {
     background-color: rgb(118, 163, 12);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(6n) {
+  .slide-this-demo:nth-child(6n) {
     background-color: rgb(180, 10, 47);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(7n) {
+  .slide-this-demo:nth-child(7n) {
     background-color: rgb(35, 99, 19);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(8n) {
+  .slide-this-demo:nth-child(8n) {
     background-color: rgb(0, 68, 255);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(9n) {
+  .slide-this-demo:nth-child(9n) {
     background-color: rgb(218, 12, 218);
   }
 
-  .my-swiper-demoeffectcards .swiper-slide:nth-child(10n) {
+  .slide-this-demo:nth-child(10n) {
     background-color: rgb(54, 94, 77);
   }
 </style>


### PR DESCRIPTION
Setting background-color: unset; in .my-slide definition is a kind of hack. It was there to unset grey background set in the geneal my-slide definition.

This component is here refactored so that:
- no div inside SwiperSlide
- each slide is of class .slide-this-demo, which defines the background color of each slide (1 color per slide)
- remove the hack

If this solution is used, next devs are:
- for all demo, do not have a div inside the SwiperSlide
- rename .my-slide in .slide-demo, which is more meaningfull

Closes #18